### PR TITLE
Fail for unsupported argument types

### DIFF
--- a/convert_xml_to_php.php
+++ b/convert_xml_to_php.php
@@ -139,6 +139,10 @@ function xmlToPhpDslValue($argument)
         return $call;
     }
 
+    if ($argType !== null) {
+        throw new \RuntimeException(\sprintf('Unsupported conversion for the argument type "%s".', $argType));
+    }
+
     return inline_var_export(convertValueToPhp($argValue));
 }
 


### PR DESCRIPTION
Failing is better than converting them in a broken way.