### PR TITLE
Add convert script to Composer bin section, update convert script to include project autoloader

### DIFF
--- a/bin/convert
+++ b/bin/convert
@@ -13,7 +13,12 @@
 use GromNaN\SymfonyConfigXmlToPhp\ConvertCommand;
 use Symfony\Component\Console\Application;
 
-require_once __DIR__ . '/../vendor/autoload.php';
+foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php'] as $file) {
+	if (file_exists($file)) {
+		require $file;
+		break;
+	}
+}
 
 $console = new Application();
 $console->add(new ConvertCommand());

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
             "Tests\\": "tests/"
         }
     },
+    "bin": [
+        "bin/convert"
+    ],
     "authors": [
         {
             "name": "Jérôme Tamarelle",


### PR DESCRIPTION
Adding to the `bin` section allows `vendor/bin/convert` to work.  The autoloader tweak is shamelessly copied from `vendor/nikic/php-parser/bin/php-parse`.