### PR TITLE
Add proper failure for files with extension config

### DIFF
--- a/src/XmlToPhpConfigConverter.php
+++ b/src/XmlToPhpConfigConverter.php
@@ -104,6 +104,10 @@ class XmlToPhpConfigConverter
      */
     private function processElement(\DOMElement $element): string
     {
+        if ($element->namespaceURI !== 'http://symfony.com/schema/dic/services') {
+            throw new \RuntimeException('Converting XML config files containing configuration for extensions is not supported.');
+        }
+
         return match ($element->nodeName) {
             'imports' => $this->processImports($element),
             'parameters' => $this->processParameters($element),


### PR DESCRIPTION
Closes https://github.com/GromNaN/symfony-config-xml-to-php/issues/11

The exist code is likely already failing due to the exhaustiveness check of the `match` expression (unless the root name of the extension config is one of the name of know tags, which is unlikely but would totally break things due to a different structure).
This provides a better error message explaining what the problem actually is.