### PR TITLE
Explicitly use functions from the Configurator namespace

### DIFF
--- a/src/XmlToPhpConfigConverter.php
+++ b/src/XmlToPhpConfigConverter.php
@@ -46,7 +46,7 @@ class XmlToPhpConfigConverter
         $output .= $this->nl(0);
 
         // Explicitly use functions from the Configurator namespace, to help static analysis tools
-        foreach (['service', 'inline_service', 'service_locator', 'iterator', 'expr', 'abstract_arg', 'env', 'service_closure', 'closure'] as $functionName) {
+        foreach (['service', 'inline_service', 'service_locator', 'iterator', 'expr', 'abstract_arg', 'env', 'service_closure', 'closure', 'tagged_iterator', 'tagged_locator'] as $functionName) {
             $output .= $this->nl().'use function \\Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\'.$functionName.';';
         }
         $output .= $this->nl(0);


### PR DESCRIPTION
This adds namespace imports for functions from the `Symfony\Component\DependencyInjection\Loader\Configurator` namespace on top of the generated files.

Technically, those imports are not necessary at runtime, since the functions can be resolved correctly without.

However, it makes a difference for tools like [ComposerRequireChecker](https://github.com/maglnet/ComposerRequireChecker/) that have to rely purely on static analysis (SA).

With SA alone, function imports may be ambiguous (see https://github.com/maglnet/ComposerRequireChecker/pull/193#issuecomment-657122649).

By adding these imports, we add more static information.