### PR TITLE
Ignore composer.lock file in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /output/
 *.cache
+/composer.lock


### PR DESCRIPTION
As the file is no longer committed, it should be ignored.