### PR TITLE
[BCBreak] Split converter from file system

### DIFF
--- a/src/ConvertCommand.php
+++ b/src/ConvertCommand.php
@@ -78,10 +78,20 @@ final class ConvertCommand extends Command
     private function processFile(SymfonyStyle $io, SplFileInfo $file, ?string $targetDir, XmlToPhpConfigConverter $converter): void
     {
         try {
-            $io->writeln('Converting: '.$file->getPathname());
+            $xmlPath = $file->getPathname();
+
+            $io->writeln('Converting: '.$xmlPath);
+
+            if (!file_exists($xmlPath)) {
+                throw new \RuntimeException(sprintf('File not found: %s', $xmlPath));
+            }
+
+            if (!str_ends_with($xmlPath, '.xml')) {
+                throw new \RuntimeException('The file must have a .xml extension.');
+            }
 
             // Generate PHP content
-            $phpContent = $converter->convertFile($file->getPathname());
+            $phpContent = $converter->convert(\file_get_contents($file->getPathname()));
 
             // Determine the output path
             $phpFilename = $file->getBasename('.xml') . '.php';

--- a/src/XmlToPhpConfigConverter.php
+++ b/src/XmlToPhpConfigConverter.php
@@ -18,22 +18,14 @@ class XmlToPhpConfigConverter
     private int $indentLevel;
 
     /**
-     * Convert an XML configuration file to PHP configuration
+     * Convert an XML configuration to PHP configuration
      */
-    public function convertFile(string $xmlPath): string
+    public function convert(string $xml): string
     {
-        if (!file_exists($xmlPath)) {
-            throw new \RuntimeException(sprintf('File not found: %s', $xmlPath));
-        }
-
-        if (!str_ends_with($xmlPath, '.xml')) {
-            throw new \RuntimeException('The file must have a .xml extension.');
-        }
-
         // Load the XML content with preserving whitespace for comment detection
         $dom = new \DOMDocument();
         $dom->preserveWhiteSpace = true;
-        $dom->load($xmlPath);
+        $dom->loadXML($xml);
 
         $this->validateNamespace($dom);
 

--- a/tests/SymfonyXmlFixturesTest.php
+++ b/tests/SymfonyXmlFixturesTest.php
@@ -62,7 +62,7 @@ class SymfonyXmlFixturesTest extends TestCase
 
         $converter = new XmlToPhpConfigConverter();
         try {
-            $phpContent = $converter->convertFile($xmlFile->getPathname());
+            $phpContent = $converter->convert(\file_get_contents($xmlFile->getPathname()));
         } catch (\Throwable $e) {
             throw new \RuntimeException(sprintf('Failed to convert XML file "%s": %s', $xmlFile->getFilename(), $e->getMessage()), 0, $e);
         }


### PR DESCRIPTION
Move reading the file also to the command. So the class can be used without a file. Maybe we could also put it on a website (Github Pages) with `php-wasm`. Think maybe @soyuka would have some experience with get PHP run in the browser so we maybe can provide a online converter :).